### PR TITLE
Extract sub-imaging controls and calibration into the plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: groovy
+sudo: false
 jdk:
 - oraclejdk7
 branches:
-  only:
-  - master
+  except:
+  - trunk
 before_install:
+- export TZ=Australia/Canberra
+- date
 - rm -rf ~/.gvm
 - curl -s get.gvmtool.net > ~/install_gvm.sh
 - chmod 775 ~/install_gvm.sh
@@ -16,7 +19,8 @@ before_install:
 - echo "GRAILS_VERSION:$GRAILS_VERSION"
 - gvm install grails $GRAILS_VERSION || true
 before_script:
-- GRAILS_VERSION_NUMBER=`echo $GRAILS_VERSION | sed -e 's/\.[0-9]*$//g' -e 's/\.//g'`
+- GRAILS_VERSION_NUMBER=`echo $GRAILS_VERSION | sed -e 's/\.[0-9]*$//g' -e 's/\.//g'
+  | tr -d "\r"`
 - echo "GRAILS_VERSION_NUMBER:$GRAILS_VERSION_NUMBER"
 - GRAILS_SETTINGS_FILE="travis_grails_settings_new.groovy"
 - if [ "$GRAILS_VERSION_NUMBER" -lt "23" ]; then GRAILS_SETTINGS_FILE="travis_grails_settings_old.groovy";
@@ -24,14 +28,16 @@ before_script:
 - echo "GRAILS_SETTINGS_FILE:$GRAILS_SETTINGS_FILE"
 - mkdir -p ~/.grails; wget -q -O ~/.grails/settings.groovy https://raw.githubusercontent.com/AtlasOfLivingAustralia/travis-build-configuration/master/$GRAILS_SETTINGS_FILE
 - MAVEN_REPO="ala-repo-snapshot"
-- grep '^\s*app\.version=' ./application.properties | grep -q "\-SNAPSHOT"; if [ "$?"
-  = "1" ]; then MAVEN_REPO="ala-repo-release"; fi;
+- APP_VERSION=`grep '^\s*def\s*version' *GrailsPlugin.groovy | sed -e 's/^.*= *"//g'
+  | sed -e 's/".*$//g' | tr -d "\r"`
+- echo $APP_VERSION | grep -q "\-SNAPSHOT"; if [ "$?" = "1" ]; then MAVEN_REPO="ala-repo-release";
+  fi;
+- echo "APP_VERSION:$APP_VERSION"
 - echo "MAVEN_REPO:$MAVEN_REPO"
 script:
-- grails clean && grails refresh-dependencies --non-interactive && grails prod maven-install --non-interactive
-after_success: '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && grails prod maven-deploy
-  --repository=$MAVEN_REPO --non-interactive'
+- grails clean && grails refresh-dependencies --non-interactive && grails prod maven-install
+  --non-interactive && grails prod maven-deploy --repository=$MAVEN_REPO --non-interactive
 env:
   global:
-  - secure: qiLV2nkvzkyR2SfvNA7P5bzvmsdH4oGmB8AO8YPWG+7SoKItV+vve+jFms9xpx7SU3wrydotUsZTcADl1vKOgGJunzT+Ge5IRs/qMqYzZn95CDYhIEAeTjK5v+1WAu/9AsvY6UchaL7Ro4dxn4n4T+p2Kngg2iZ+u+k9fZl5Pck=
-  - secure: b/Db5lJNIJBnjbzcc7EYnEKJT45U21QA/LvUuO8RApBsq+fuL8EOmymShjK0l0XcMHPNxi51fgUbJ/wMqMuMgEgYAV79oYajrVpe7v+GN2ng1f6ZB6MaaKqyHu71nf87XqsDNCSOLknI+oi4BenHgufzYNMoqZcML6+JILqL7bs=
+  - secure: 8H8KsZuqo9KMJJRgl6w5TzBj2XIPYzxQfE/KvlV3PPLvwmJoL1d18Voh4vnAR3SA5WGI+ZlRBHZxbGDjRigIE4FpxN0WoDkGpRZVB/5nChH+ldViiYejDL4IkBmbhqG8x7zZ2GghLdeXqoQc3bqeaskxOBBmlYGMSA9YUWI4j4s=
+  - secure: DDeOByG9Mvo4bGVNgj54aqpQf8MrOQ7LP5Rha9TBScj9EHIPvp7trsoe0mJ6W/7gTZxPj5dO4qJIOR3m5WnhLgCQ9kNBUrzT7i/OcRkRraxVvO1XxeeEBpG2fooF1fdakrEv2Vq7Eh/Io/drnqPOgLBLtfwBvgKb4390sZPkpdA=

--- a/ImagesClientPluginGrailsPlugin.groovy
+++ b/ImagesClientPluginGrailsPlugin.groovy
@@ -1,6 +1,6 @@
 class ImagesClientPluginGrailsPlugin {
     // the plugin version
-    def version = "0.4-SNAPSHOT"
+    def version = "0.6-SNAPSHOT"
     // the version or versions of Grails the plugin is designed for
     def grailsVersion = "2.2 > *"
     // resources that are excluded from plugin packaging

--- a/grails-app/conf/ImagesClientResources.groovy
+++ b/grails-app/conf/ImagesClientResources.groovy
@@ -21,8 +21,8 @@ modules = {
         resource url: [plugin: "images-client-plugin", dir: 'js/audiojs', file: 'audio.min.js']
     }
 
-    viewer {
-        dependsOn 'jquery', 'leaflet', 'leaflet_draw', 'font-awesome'
+    image_viewer {
+        dependsOn 'jquery', 'bootstrap', 'leaflet', 'leaflet_draw', 'font-awesome'
         resource url: [plugin: "images-client-plugin", dir: 'js', file: 'ala-image-viewer.js']
     }
 }

--- a/grails-app/views/imageClient/uploadFromCSVFragment.gsp
+++ b/grails-app/views/imageClient/uploadFromCSVFragment.gsp
@@ -51,8 +51,6 @@
         }, 1000);
     }
 
-
-
     $("#btnCancelCSVFileUpload").click(function(e) {
         e.preventDefault();
         imglib.hideModal();

--- a/web-app/js/ala-image-viewer.js
+++ b/web-app/js/ala-image-viewer.js
@@ -3,11 +3,18 @@ var imgvwr = {};
 (function(lib) {
 
     var map_registry = {};
+    var imageServiceBaseUrl = "http://dev.ala.org.au:8080/ala-images";
 
     var base_options = {
-        imageServiceBaseUrl: "http://images.ala.org.au",
+        imageServiceBaseUrl:  "http://dev.ala.org.au:8080/ala-images",
         auxDataUrl: '',
-        initialZoom: 'auto'
+        auxDataTitle: 'View more information about this image',
+        initialZoom: 'auto',
+        addDownloadButton: true,
+        addDrawer: true,
+        addSubImageToggle: true,
+        addCalibration: true,
+        addImageInfo: true
     };
 
     lib.viewImage = function(targetDiv, imageId, options) {
@@ -37,12 +44,14 @@ var imgvwr = {};
     }
 
     function initViewer(opts) {
+
+        imageServiceBaseUrl = opts.imageServiceBaseUrl;
+
         $.ajax( {
             dataType: 'jsonp',
-            url: opts.imageServiceBaseUrl + "/ws/getImageInfo/" + opts.imageId,
+            url: imageServiceBaseUrl + "/ws/getImageInfo/" + opts.imageId,
             crossDomain: true
         }).done(function(image) {
-
             if (image.success) {
                 _createViewer(opts, image);
             }
@@ -51,9 +60,12 @@ var imgvwr = {};
 
     function _createViewer(opts, image) {
 
+        var imageId = opts.imageId;
+        imageServiceBaseUrl = opts.imageServiceBaseUrl;
         var maxZoom = image.tileZoomLevels ? image.tileZoomLevels - 1 : 0;
 
         var imageScaleFactor =  Math.pow(2, maxZoom);
+        var imageHeight = image.height;
 
         var centerx = image.width / 2 / imageScaleFactor;
         var centery = image.height / 2 / imageScaleFactor;
@@ -64,13 +76,24 @@ var imgvwr = {};
 
         var measureControlOpts = false;
 
-        if (image.mmPerPixel) {
+        var drawnItems = new L.FeatureGroup();
+
+        var imageOverlays = new L.FeatureGroup();
+
+        if(opts.addCalibration) {
             measureControlOpts = {
                 mmPerPixel: image.mmPerPixel,
                 imageScaleFactor: imageScaleFactor,
                 imageWidth: image.width,
                 imageHeight: image.height,
-                hideCalibration: true
+                hideCalibration: !opts.addCalibration,
+                onCalibration: function (pixels) {
+                    var opts = {
+                        url: imageServiceBaseUrl + "/dialog/calibrateImageFragment/" + imageId + "?pixelLength=" + Math.round(pixels),
+                        title: 'Calibrate image scale'
+                    };
+                    lib.showModal(opts);
+                }
             };
         }
 
@@ -78,7 +101,7 @@ var imgvwr = {};
 
         // Check if this element has already been initialized as a leaflet viewer
         if (map_registry[target]) {
-            // if so, we need to uninitialize it
+            // if so, we need to un-initialize it
             map_registry[target].remove();
             delete map_registry[target];
         }
@@ -89,9 +112,11 @@ var imgvwr = {};
             minZoom: 2,
             maxZoom: maxZoom,
             zoom: getInitialZoomLevel(opts.initialZoom, maxZoom, image, opts.target),
-            center:new L.LatLng(centery, centerx),
+            center: new L.LatLng(centery, centerx),
             crs: L.CRS.Simple
         });
+
+        viewer.addLayer(drawnItems);
 
         map_registry[target] = viewer;
 
@@ -105,20 +130,22 @@ var imgvwr = {};
             bounds: bounds
         }).addTo(viewer);
 
-        var ImageInfoControl = L.Control.extend( {
+        if (opts.addImageInfo){
+            var ImageInfoControl = L.Control.extend( {
 
-            options: {
-                position: "bottomleft",
-                title: 'Image details'
-            },
-            onAdd: function (map) {
-                var container = L.DomUtil.create("div", "leaflet-bar");
-                var detailsUrl = opts.imageServiceBaseUrl + "/image/details/" + opts.imageId;
-                $(container).html("<a href='" + detailsUrl + "' title='" + this.options.title + "'><span class='fa fa-external-link'></span></a>");
-                return container;
-            }
-        });
-        viewer.addControl(new ImageInfoControl());
+                options: {
+                    position: "bottomleft",
+                    title: 'Image details'
+                },
+                onAdd: function (map) {
+                    var container = L.DomUtil.create("div", "leaflet-bar");
+                    var detailsUrl = imageServiceBaseUrl + "/image/details/" + opts.imageId;
+                    $(container).html("<a href='" + detailsUrl + "' title='" + this.options.title + "'><span class='fa fa-external-link'></span></a>");
+                    return container;
+                }
+            });
+            viewer.addControl(new ImageInfoControl());
+        }
 
         if (opts.auxDataUrl) {
 
@@ -130,7 +157,7 @@ var imgvwr = {};
                 },
                 onAdd: function (map) {
                     var container = L.DomUtil.create("div", "leaflet-bar");
-                    $(container).html("<a id='btnImageAuxInfo' href='#'><span class='fa fa-info'></span></a>");
+                    $(container).html("<a id='btnImageAuxInfo' title='" + opts.auxDataTitle + "' href='#'><span class='fa fa-info'></span></a>");
                     $(container).find("#btnImageAuxInfo").click(function (e) {
                         e.preventDefault();
                         $.ajax( {
@@ -165,6 +192,212 @@ var imgvwr = {};
             });
 
             viewer.addControl(new AuxInfoControl());
+        }
+
+        if (opts.addDownloadButton) {
+
+            var DownloadControl = L.Control.extend({
+
+                options: {
+                    position: "topleft",
+                    title: 'Download button'
+                },
+                onAdd: function (map) {
+                    var container = L.DomUtil.create("div", "leaflet-bar");
+                    $(container).html("<a id='btnDownload' title='Download this image' href='#'><span class='fa fa-download'></span></a>");
+                    $(container).find("#btnDownload").click(function (e) {
+                        e.preventDefault();
+                        window.location.href = opts.imageServiceBaseUrl + "/image/proxyImage/" + opts.imageId + "?contentDisposition=true";
+                    });
+                    return container;
+                }
+            });
+
+            viewer.addControl(new DownloadControl());
+        }
+
+        if (opts.addDrawer){
+            // Initialise the draw control and pass it the FeatureGroup of editable layers
+            var drawControl = new L.Control.Draw({
+                edit: {
+                    featureGroup: drawnItems
+                },
+                draw: {
+                    position: 'topleft',
+                    circle: false,
+                    rectangle: {
+                        shapeOptions: {
+                            weight: 1,
+                            color: 'blue'
+                        }
+                    },
+                    marker: false,
+                    polyline: false,
+                    polygon: false
+                }
+
+            });
+            viewer.addControl(drawControl);
+
+            $(".leaflet-draw-toolbar").last().append('<a id="btnCreateSubimage" class="viewer-custom-buttons leaflet-disabled fa fa-picture-o" href="#" title="Draw a rectangle to create a sub image"></a>');
+
+            $("#btnCreateSubimage").click(function(e) {
+                e.preventDefault();
+
+                var layers = drawnItems.getLayers();
+                if (layers.length <= 0) {
+                    return;
+                }
+
+                var ll = layers[0].getLatLngs();
+
+                // Need to calculate x,y,height and width, where x is the min longitude,
+                // y = min latitude, height = max latitude - y and width = max longitude - x
+                var minx = image.width, miny = image.height, maxx = 0, maxy = 0;
+
+                for (var i = 0; i < ll.length; ++i) {
+                    var y = Math.round(image.height - ll[i].lat * imageScaleFactor);
+                    var x = Math.round(ll[i].lng * imageScaleFactor);
+
+                    if (y < miny) {
+                        miny = y;
+                    }
+                    if (y > maxy) {
+                        maxy = y;
+                    }
+                    if (x < minx) {
+                        minx = x;
+                    }
+                    if (x > maxx) {
+                        maxx = x;
+                    }
+                }
+
+                var height = maxy - miny;
+                var width = maxx - minx;
+
+                var url = imageServiceBaseUrl + "/image/createSubimageFragment/" + imageId + "?x=" + minx + "&y=" + miny + "&width=" + width + "&height=" + height;
+                var opts = {
+                    title: "Create subimage",
+                    url: url,
+                    onClose: function() {
+                        drawnItems.clearLayers();
+                    }
+                };
+                lib.showModal(opts);
+            });
+
+            viewer.on('draw:created', function (e) {
+                //var type = e.layerType,
+                var layer = e.layer;
+                drawnItems.clearLayers();
+                drawnItems.addLayer(layer);
+                $("#btnCreateSubimage").removeClass("leaflet-disabled");
+                $("#btnCreateSubimage").attr("title", "Create a subimage from the currently drawn rectangle");
+            });
+
+            viewer.on('draw:deleted', function (e) {
+                var button = $("#btnCreateSubimage");
+                button.addClass("leaflet-disabled");
+                button.attr("title", "Draw a rectangle to create a subimage");
+
+            });
+        }
+
+        if (opts.addSubImageToggle){
+
+           viewer.addLayer(imageOverlays);
+
+            var ViewSubImagesControl = L.Control.extend({
+
+                options: {
+                    position: "topright",
+                    title: 'View subimages button'
+                },
+                onAdd: function (map) {
+                    var container = L.DomUtil.create("div", "leaflet-bar");
+                    $(container).html("<a id='btnViewSubimages' title='View subimages' href='#' style='width:110px;'>Show&nbsp;subimages</a>");
+                    $(container).find("#btnViewSubimages").click(function (e) {
+                        e.preventDefault();
+                        var isShowing = hookShowSubimages();
+                        if(isShowing){
+                           $('#btnViewSubimages').html('Hide&nbsp;subimages');
+                        } else {
+                           $('#btnViewSubimages').html('Show&nbsp;subimages');
+                        }
+                    });
+                    return container;
+                }
+            });
+
+            function hookShowSubimages() {
+
+                if (imageOverlays.getLayers().length == 0) {
+                    $.ajax(imageServiceBaseUrl + "/ws/getSubimageRectangles/" + opts.imageId).done(function(results) {
+                        if (results.success) {
+                            for (var subimageIndex in results.subimages) {
+
+                                var rect = results.subimages[subimageIndex];
+                                var imageId = rect.imageId;
+                                var lng1 = rect.x / imageScaleFactor;
+                                var lat1 = (imageHeight - rect.y) / imageScaleFactor;
+                                var lng2 = (rect.x + rect.width) / imageScaleFactor;
+                                var lat2 = (imageHeight - (rect.y + rect.height)) / imageScaleFactor;
+                                var bounds = [[lat1,lng1], [lat2, lng2]];
+
+                                var feature = L.rectangle(bounds, { color: "#ff7800", weight: 1, imageId:imageId, className: imageId});
+                                feature.addTo(imageOverlays);
+                                feature.on("click", function(e) {
+                                    var imageId = e.target.options.imageId;
+                                    if (imageId) {
+                                        window.location = imageServiceBaseUrl + "/image/details?imageId=" + imageId;
+                                    }
+                                });
+
+                                feature.on('mouseover', function (e) {
+
+                                    var popup = L.popup()
+                                        .setLatLng(e.latlng) //(assuming e.latlng returns the coordinates of the event)
+                                        .setContent('<p>Loading..' + e.target.options.imageId +'.</p>')
+                                        .openOn(viewer);
+                                    console.log('loading ' + e.target.options.imageId);
+
+                                    $.ajax( imageServiceBaseUrl + "/image/imageTooltipFragment?imageId=" + e.target.options.imageId).then(function(content) {
+                                        popup.setContent(content);
+                                    },
+                                    function(xhr, status, error) {
+                                        console.log( status + ": " + error);
+                                    });
+                                });
+                                feature.on('mouseout', function (e) {
+                                    this.closePopup();
+                                });
+                            }
+
+                            $(".subimage-path").each(function() {
+                                var classNames = $(this).attr("class");
+                                classNames = $.trim(classNames).split(" ");
+                                // Work out the imageId
+                                var imageId = "";
+                                for (index in classNames) {
+                                    var className = classNames[index];
+                                    var matches = className.match(/imageId[-](.*)/);
+                                    if (matches) {
+                                        imageId = matches[1];
+                                        break;
+                                    }
+                                }
+                            });
+                        }
+                    });
+                    return true;
+                } else {
+                    imageOverlays.clearLayers();
+                    return false
+                }
+            }
+
+            viewer.addControl(new ViewSubImagesControl());
         }
     }
 
@@ -249,11 +482,214 @@ var imgvwr = {};
             keyboard: opts.keyboard,
             backdrop: opts.backdrop
         });
-
     };
 
     lib.hideModal = function() {
         $("#modal_element_id").modal('hide');
     };
 
+    lib.areYouSureOptions = {};
+
+    lib.areYouSure = function(options) {
+
+        if (!options.title) {
+            options.title = "Are you sure?"
+        }
+
+        if (!options.message) {
+            options.message = options.title;
+        }
+
+        var modalOptions = {
+            url: imageServiceBaseUrl + "/dialog/areYouSureFragment?message=" + encodeURIComponent(options.message),
+            title: options.title
+        };
+
+        lib.areYouSureOptions.affirmativeAction = options.affirmativeAction;
+        lib.areYouSureOptions.negativeAction = options.negativeAction;
+
+        lib.showModal(modalOptions);
+    };
+
+    lib.onAlbumSelected = null;
+
+    lib.selectAlbum = function(onSelectFunction) {
+        var opts = {
+            title: "Select an album",
+            url: imageServiceBaseUrl + "/album/selectAlbumFragment"
+        };
+        lib.onAlbumSelected = function(albumId) {
+            lib.hideModal();
+            if (onSelectFunction) {
+                onSelectFunction(albumId);
+            }
+        };
+        lib.showModal(opts);
+    };
+
+    lib.onTagSelected = null;
+
+    lib.onTagCreated = null;
+
+    lib.selectTag = function(onSelectFunction) {
+        var opts = {
+            width: 700,
+            title: "Select a tag",
+            url: imageServiceBaseUrl + "/tag/selectTagFragment"
+        };
+
+        lib.onTagSelected = function(tagId) {
+            lib.hideModal();
+            if (onSelectFunction) {
+                onSelectFunction(tagId);
+            }
+        };
+        lib.showModal(opts);
+    };
+
+    lib.createNewTag = function(parentTagId, onCreatedFunction) {
+
+        var opts = {
+            title: "Create new tag from path",
+            url: imageServiceBaseUrl + "/tag/createTagFragment?parentTagId=" + parentTagId
+        };
+
+        lib.onTagCreated = function(tagId) {
+            lib.hideModal();
+            if (onCreatedFunction) {
+                onCreatedFunction(tagId);
+            }
+        };
+        lib.showModal(opts);
+    };
+
+    lib.onAddMetadata = null;
+
+    lib.promptForMetadata = function(onMetadata) {
+
+        var opts = {
+            title: "Add meta data item",
+            url: imageServiceBaseUrl + "/dialog/addUserMetadataFragment"
+        };
+
+        lib.onAddMetadata = function(key, value) {
+            lib.hideModal();
+            if (onMetadata) {
+                onMetadata(key, value);
+            }
+        };
+
+        lib.showModal(opts);
+    };
+
+    lib.bindImageTagTooltips = function() {
+        $(".image-tags-button").each(function() {
+            var imageId = $(this).closest("[imageId]").attr("imageId");
+            if (imageId) {
+                $(this).qtip({
+                    content: {
+                        text: function(event, api) {
+                            $.ajax(imageServiceBaseUrl + "/image/imageTagsTooltipFragment/" + imageId).then(function(content) {
+                                    api.set("content.text", content);
+                                },
+                                function(xhr, status, error) {
+                                    api.set("content.text", status + ": " + error);
+                                });
+                        }
+                    }
+                });
+            }
+        });
+    };
+
+    lib.htmlEscape = function(str) {
+        return String(str)
+            .replace(/&/g, '&amp;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;');
+    };
+
+    lib.htmlUnescape = function(value) {
+        return String(value)
+            .replace(/&quot;/g, '"')
+            .replace(/&#39;/g, "'")
+            .replace(/&lt;/g, '<')
+            .replace(/&gt;/g, '>')
+            .replace(/&amp;/g, '&');
+    };
+
+    lib.showSpinner = function(message) {
+        var spinner = $(".spinner");
+        if (message) {
+            spinner.attr("title", message);
+        } else {
+            spinner.attr("title", "");
+        }
+        spinner.css("display", "block");
+    };
+
+    lib.hideSpinner = function() {
+        var spinner = $(".spinner");
+        spinner.css("display", "none");
+    };
+
+    lib.bindTooltips = function(selector, width) {
+
+        if (!selector) {
+            selector = "a.fieldHelp";
+        }
+        if (!width) {
+            width = 300;
+        }
+        // Context sensitive help popups
+        $(selector).each(function() {
+
+
+            var tooltipPosition = $(this).attr("tooltipPosition");
+            if (!tooltipPosition) {
+                tooltipPosition = "bottomRight";
+            }
+
+            var targetPosition = $(this).attr("targetPosition");
+            if (!targetPosition) {
+                targetPosition = "topMiddle";
+            }
+            var tipPosition = $(this).attr("tipPosition");
+            if (!tipPosition) {
+                tipPosition = "bottomRight";
+            }
+
+            var elemWidth = $(this).attr("width");
+            if (elemWidth) {
+                width = elemWidth;
+            }
+
+            $(this).qtip({
+                tip: true,
+                position: {
+                    corner: {
+                        target: targetPosition,
+                        tooltip: tooltipPosition
+                    }
+                },
+                style: {
+                    width: width,
+                    padding: 8,
+                    background: 'white', //'#f0f0f0',
+                    color: 'black',
+                    textAlign: 'left',
+                    border: {
+                        width: 4,
+                        radius: 5,
+                        color: '#E66542'// '#E66542' '#DD3102'
+                    },
+                    tip: tipPosition,
+                    name: 'light' // Inherit the rest of the attributes from the preset light style
+                }
+            }).bind('click', function(e){ e.preventDefault(); return false; });
+
+        });
+    };
 })(imgvwr);


### PR DESCRIPTION
I've spent yesterday extracting out some of the JS tools from image-service into this plugin so they can be reused in different apps (specimenbrowser, taxonoverflow, biocache, pigeonhole).

This PR is coupled with another PR (yet to be submitted) which is for the [image-service](http://github.com/atlasoflivingaustralia/image-service).

Ive made changes so that image-service has a dependency on images-client-plugin for the JS tools to avoid code duplication and so that we have a single plugin for image tools that use the image-service.

cc @nickdos 
