### PR TITLE
Trim whitespace about roles

### DIFF
--- a/grails-app/taglib/images/client/plugin/ImageClientTagLib.groovy
+++ b/grails-app/taglib/images/client/plugin/ImageClientTagLib.groovy
@@ -15,7 +15,7 @@ class ImageClientTagLib implements GrailsConfigurationAware {
     @Override
     void setConfiguration(Config config) {
         def roleList = config.getProperty("allowedImageEditingRoles", "")
-        allowedRoles = roleList ? roleList.split(",") : []
+        allowedRoles = roleList ? roleList.split(",").collect({ it.trim() }) : []
     }
 /**
      *


### PR DESCRIPTION
Improvement for https://github.com/AtlasOfLivingAustralia/images-client-plugin/pull/16 to handle whitespace in config